### PR TITLE
User Auth testing and enforcing passwordDigest during tests

### DIFF
--- a/lib/spareCoins.js
+++ b/lib/spareCoins.js
@@ -128,12 +128,6 @@
         }
 
         callback( true );
-
-        // if ( passwordDigest !== undefined || passwordDigest !== "" ) {
-        //   callback( true )
-        // } else {
-        //   callback( false )
-        // }
       } )
     }
 
@@ -308,7 +302,13 @@
       // TODO: Check for presence
       var encryptedRoot = fCryptPrivateKey;
       var decrypted = CryptoJS.AES.decrypt( encryptedRoot, passwordDigest );
-      fPrivateKey = decrypted.toString( CryptoJS.enc.Utf8 );
+
+      try {
+        fPrivateKey = decrypted.toString( CryptoJS.enc.Utf8 );
+      } catch ( err ) {
+        return false;
+      }
+
       if ( fPrivateKey === "" ) {
         return false;
       }

--- a/test/test.sparecoins.js
+++ b/test/test.sparecoins.js
@@ -70,7 +70,8 @@ describe( "Wallet", function() {
     var Wallet = new SpareCoins.Wallet( testStorage )
     Wallet.loadData( function() {
       for ( var i = 0; i < 10; ++i ) {
-        Wallet.generateAddress( "passwordDigest" );
+        var passwordDigest = Crypto.SHA256( "testPassword" );
+        Wallet.generateAddress( passwordDigest );
       }
       expect( Wallet.getAddresses().length ).to.eq( 10 );
       done();
@@ -96,7 +97,8 @@ describe( "Wallet", function() {
   it( "is able to generate and save new addresses", function( done ) {
     var Wallet = new SpareCoins.Wallet( testStorage )
     Wallet.loadData( function() {
-      var address = Wallet.generateAddress( "passwordDigest" );
+      var passwordDigest = Crypto.SHA256( "testPassword" );
+      var address = Wallet.generateAddress( passwordDigest );
       expect( address.getPrivateKey() ).to.eq( undefined );
       expect( address.getfCryptPrivateKey().constructor ).to.eq( String );
       done();
@@ -132,7 +134,8 @@ describe( "Wallet", function() {
 
   it( "build a pushable transaction", function( done ) {
     this.timeout( 10000 );
-    new SpareCoins.Address( "", "", "" ).save( "passwordDigest", testStorage );
+    var passwordDigest = Crypto.SHA256( "testPassword" );
+    new SpareCoins.Address( "", "", "" ).save( passwordDigest, testStorage );
 
     var Wallet = new SpareCoins.Wallet( testStorage );
     Wallet.loadData( function() {
@@ -142,10 +145,8 @@ describe( "Wallet", function() {
         value: BigInteger.valueOf( 1000 )
       } ];
 
-      Wallet.buildPendingTransaction( toAddresses, "passwordDigest", function( pendingTransaction ) {
-
-        alert( pendingTransaction.serialize(), pendingTransaction.txHash() );
-
+      Wallet.buildPendingTransaction( toAddresses, passwordDigest, function( pendingTransaction ) {
+        console.log( pendingTransaction.serialize(), pendingTransaction.txHash() );
         done();
       } );
     } );
@@ -169,10 +170,10 @@ describe( "Address", function() {
   it( "able to encrypt and decrypt privateKey using password digest", function( done ) {
     var newAddress = new SpareCoins.Address();
     var originalPrivateKey = newAddress.getPrivateKey();
-
-    newAddress.encrypt( "passwordDigest" );
+    var passwordDigest = Crypto.SHA256( "testPassword" );
+    newAddress.encrypt( passwordDigest );
     expect( newAddress.getPrivateKey() ).to.eq( undefined );
-    newAddress.decrypt( "passwordDigest" );
+    newAddress.decrypt( passwordDigest );
     expect( newAddress.getPrivateKey() ).to.eq( originalPrivateKey );
     done();
   } );
@@ -206,4 +207,41 @@ describe( "Util", function() {
   it( "sums Unspents", function() {
 
   } );
-} )
+} );
+
+describe( "Authentication", function() {
+  it( "isAuthenticated checks for the presence of passwordDigest", function( done ) {
+    testStorage.clear( "security" );
+    var Wallet = new SpareCoins.Wallet( testStorage )
+    // Test 1
+    Wallet.isAuthenticated( function( authenticated ) {
+      expect( authenticated ).to.eq( false );
+
+      // Test 2
+      testStorage.clear( "security" );
+      testStorage.set( "security", "passwordDigest", "123" )
+
+      Wallet = new SpareCoins.Wallet( testStorage )
+      Wallet.isAuthenticated( function( authenticated ) {
+        expect( authenticated ).to.eq( true );
+        done();
+      } );
+    } );
+
+  } );
+
+  it( "authenticate tries to decrypt an address and returns true if successful", function( done ) {
+    testStorage.clear( "wallet" );
+    var Wallet = new SpareCoins.Wallet( testStorage )
+    var passwordDigest = Crypto.SHA256( "testPassword" );
+    var address = Wallet.generateAddress( passwordDigest );
+    Wallet.loadData( function() {
+      expect( Wallet.authenticate( "wrongPassword" ) ).to.eq( false );
+    } );
+    var Wallet = new SpareCoins.Wallet( testStorage )
+    Wallet.loadData( function() {
+      expect( Wallet.authenticate( "testPassword" ) ).to.eq( true );
+      done();
+    } );
+  } );
+} );


### PR DESCRIPTION
@locksley, since we are now using passwordDigest for tests make sure that during tests you first sha256 the test password before passing it into functions like Wallet.generateAddress( ... )
